### PR TITLE
fix: use official npm registry for iconv-lite resolved URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -687,7 +687,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
iconv-lite 的 resolved 残留中国镜像 URL (registry.npmmirror.com)， 与其余依赖 (registry.npmjs.org) 的 origin 不一致。npm 12 默认
allow-remote=none，会把该普通 registry tarball 误判为 remote 依赖， 导致 npm install 报 EALLOWREMOTE 构建失败。